### PR TITLE
[codex] Restrict accounting menu to accountants

### DIFF
--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -46,7 +46,7 @@ export const routes = [
         name: "Cari Hesaplar",
         path: "/cari-hesaplar",
         element: <AccountingPage />,
-        roles: ['admin', 'muhasebeci'],
+        roles: ['muhasebeci'],
       },
       {
         icon: <ClipboardDocumentListIcon {...icon} />,


### PR DESCRIPTION
## Summary
- Hide the `Cari Hesaplar` accounting menu from admin users.
- Keep the accounting menu visible only for users with the `muhasebeci` role.

## Validation
- `npm run build`

## Notes
- A manual MSSQL script can be used to create a `Muhasebeci` user in the backend database.